### PR TITLE
Add a warning if output type id not numeric

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -31,9 +31,6 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
-          - {os: ubuntu-latest,   r: 'oldrel-2'}
-          - {os: ubuntu-latest,   r: 'oldrel-3'}
-          - {os: ubuntu-latest,   r: 'oldrel-4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubVis
 Title: Plotting methods for hub models output
-Version: 0.0.0.9000
+Version: 0.0.0.9001
 Authors@R: 
     c(person("Lucie", "Contamin", , "contamin@pitt.edu", role = c("aut", "cre"),
              comment = c(ORCID = "0000-0001-5797-1279")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,10 @@
+
+# hubVis 0.0.0.9001
+
+This release contains a bug fix for `plot_step_ahead_model_output()` returns
+warning instead of an error for `output_type_id` column in class character
+instead of numeric (#18)
+
+# hubVis 0.0.0.9000
+
+* Release of first draft `hubVis` package

--- a/R/plot_step_ahead_model_output.R
+++ b/R/plot_step_ahead_model_output.R
@@ -3,8 +3,8 @@
 #' Create a simple Plotly time-series plot for model projection outputs.
 #'
 #'@param model_output_data a `model_out_tbl` object, containing all the required
-#' columns, a column containing date information (`x_col_name` parameter) and
-#' a column `value`.
+#' columns including a column containing date information (`x_col_name`
+#' parameter) and a column `value`.
 #'@param truth_data a `data.frame` object containing the ground truth data,
 #' with a column containing date information (`x_truth_col_name` parameter) and
 #' a column `value`. Ignored, if `plot_truth = FALSE`.
@@ -198,6 +198,14 @@ plot_step_ahead_model_output <- function(
     cli::cli_abort(c("x" = "{.arg model_output_type_val} did not have the
                      expected output_type_id value {.val {exp_value}}"))
   }
+  if (!class(exp_value) %in% class(model_output_type_val)) {
+    model_output_data$output_type_id <- as.numeric(
+      model_output_data$output_type_id)
+    cli::cli_warn(c("!" = "{.arg output_type_id} column must be a numeric.
+                    . Class applied by default."))
+  }
+
+
   ### Ensemble specific color
   if (is.null(ens_color) + is.null(ens_name) == 1) {
     cli::cli_abort(c("x" = "Both {.arg ens_color} and {.arg ens_name} should

--- a/R/plot_step_ahead_model_output.R
+++ b/R/plot_step_ahead_model_output.R
@@ -202,7 +202,7 @@ plot_step_ahead_model_output <- function(
     model_output_data$output_type_id <- as.numeric(
       model_output_data$output_type_id)
     cli::cli_warn(c("!" = "{.arg output_type_id} column must be a numeric.
-                    . Class applied by default."))
+                    Class applied by default."))
   }
 
 

--- a/man/plot_step_ahead_model_output.Rd
+++ b/man/plot_step_ahead_model_output.Rd
@@ -32,8 +32,8 @@ plot_step_ahead_model_output(
 }
 \arguments{
 \item{model_output_data}{a \code{model_out_tbl} object, containing all the required
-columns, a column containing date information (\code{x_col_name} parameter) and
-a column \code{value}.}
+columns including a column containing date information (\code{x_col_name}
+parameter) and a column \code{value}.}
 
 \item{truth_data}{a \code{data.frame} object containing the ground truth data,
 with a column containing date information (\code{x_truth_col_name} parameter) and

--- a/tests/testthat/test-plot_step_ahead_model_output.R
+++ b/tests/testthat/test-plot_step_ahead_model_output.R
@@ -26,6 +26,12 @@ test_that("Input parameters", {
   expect_warning(plot_step_ahead_model_output(projection_data_A_us,
                                                         truth_data_us))
   projection_data_A_us <- hubUtils::as_model_out_tbl(projection_data_A_us)
+  projection_data_A_us_w <-  dplyr::mutate(
+    projection_data_A_us, output_type_id = as.character(output_type_id))
+  expect_warning(plot_step_ahead_model_output(projection_data_A_us_w,
+                                              truth_data_us))
+
+
   # Column
   expect_error(plot_step_ahead_model_output(
     projection_data_A_us, truth_data_us, x_col_name = "date"))


### PR DESCRIPTION
Add a warning and automatically transform the `output_type_id` column to numeric if necessary.

Fix issue #18 

``` r
hub_path <- system.file("example-data/example-simple-forecast-hub",
                        package = "hubEnsembles")
model_outputs <- hubUtils::connect_hub(hub_path) |>
  dplyr::collect()
target_data_path <- file.path(hub_path, "target-data", "covid-hospitalizations.csv")
target_data <- read.csv(target_data_path) |>
  dplyr::mutate(time_idx = as.Date(time_idx))

hubVis::plot_step_ahead_model_output(model_output_data = model_outputs |>
                                       dplyr::filter(location == "US",
                                                     output_type %in% c("quantile"),
                                                     origin_date == "2022-12-12") |>
                                       dplyr::mutate(target_date =  origin_date + horizon),
                                     truth_data = target_data |>
                                       dplyr::filter(location == "US",
                                                     time_idx >= "2022-11-01",
                                                     time_idx <= "2023-03-01"),
                                     facet = "model_id", 
                                     facet_nrow = 1, 
                                     interactive = FALSE,
                                     intervals = 0.5,
                                     one_color = "black",
                                     pal_color = NULL, 
                                     show_legend = FALSE, 
                                     use_median_as_point = TRUE)
#> Warning: ! `model_output_data` must be a `model_out_tbl`. Class applied by
#> default
#> Warning: ! `output_type_id` column must be a numeric. . Class applied by
#> default.
```
 The plot should appear as expected after the warnings (instead of an error stopping the plot)

<sup>Created on 2024-01-17 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>