### PR TITLE
Split hubutils - use v0.0.1

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: any::rcmdcheck, any::tzdb
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, any::tzdb
+          extra-packages: any::rcmdcheck
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     scales,
     stats
 Remotes:
-    Infectious-Disease-Modeling-Hubs/hubUtils#143
+    Infectious-Disease-Modeling-Hubs/hubUtils
 Suggests:
     rmarkdown,
     testthat (>= 3.0.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
     dplyr,
     ggplot2,
     grDevices,
-    hubUtils,
+    hubUtils (>= 0.0.1),
     methods,
     plotly,
     purrr,
@@ -25,12 +25,12 @@ Imports:
     scales,
     stats
 Remotes:
-    Infectious-Disease-Modeling-Hubs/hubUtils
+    Infectious-Disease-Modeling-Hubs/hubUtils#143
 Suggests:
     rmarkdown,
     testthat (>= 3.0.0)
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 URL: https://github.com/Infectious-Disease-Modeling-Hubs/hubVis,
     https://infectious-disease-modeling-hubs.github.io/hubVis/
 BugReports: https://github.com/Infectious-Disease-Modeling-Hubs/hubVis/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,8 +25,10 @@ Imports:
     scales,
     stats
 Remotes:
-    Infectious-Disease-Modeling-Hubs/hubUtils
+    Infectious-Disease-Modeling-Hubs/hubUtils,
+    Infectious-Disease-Modeling-Hubs/hubData
 Suggests:
+    hubData,
     rmarkdown,
     testthat (>= 3.0.0)
 Roxygen: list(markdown = TRUE)

--- a/vignettes/plot_projection.Rmd
+++ b/vignettes/plot_projection.Rmd
@@ -37,7 +37,7 @@ The following vignette describes the principal usage of the
 
 ```{r lib}
 library(hubVis)
-library(hubUtils)
+library(hubData)
 ```
 
 Plots are available in two output formats:
@@ -65,7 +65,7 @@ function: `hubEnsembles::simple_ensemble(df_round1, agg_fun = "median")`
 ```{r load_data}
 projection_path <- system.file("example_round1.csv", package = "hubVis")
 projection_data <- read.csv(projection_path, stringsAsFactors = FALSE)
-projection_data <- as_model_out_tbl(projection_data)
+projection_data <- hubData::as_model_out_tbl(projection_data)
 head(projection_data)
 
 target_path <- system.file("target_data.csv", package = "hubVis")


### PR DESCRIPTION
Add functionality split from `hubUtils`

Currently, the `hubUtils` version in a specific PR in the `hubUtils` repo is being specified for testing that all will work fine with updated version. Once `hubUtils` v0.0.1 is merged in, I'll update the `DESCRIPTION` to use the `main` `hubUtils` branch again.

Details of the split can be found in `hubUtils`  `NEWS.md`, reproduced below:

> * First **major release of `hubUtils` package** containing significant breaking changes. Much of the package has been moved and split across two smaller and more dedicated packages:
>  - **`hubData` package**: contains functions for connecting to and interacting with hub data. 
>    * Exported functions moved to `hubData`: `connect_hub()`, `connect_model_output()`, `expand_model_out_val_grid()`, `create_model_out_submit_tmpl()`, `coerce_to_character()`, `coerce_to_hub_schema()` and `create_hub_schema()`.
>    * `hubUtils` functions re-exported to `hubData`: `as_model_out_tbl()`, `validate_model_out_tbl()`, `model_id_split()` and `model_id_merge()`.
>  - **`hubAdmin` package**: contains functions for administering Hubs, in particular creating and validating hub configuration files. Exported functions moved to `hubAdmin`: 
>    * Functions for creating config files: `create_config()`, `create_model_task()`, `create_model_tasks()`, `create_output_type()`, `create_output_type_cdf()`, `create_output_type_mean()`, `create_output_type_median()`, `create_output_type_pmf()`, `create_output_type_quantile()`, `create_output_type_sample()`, `create_round()`, `create_rounds()`, `create_target_metadata()`, `create_target_metadata_item()`, `create_task_id()`, `create_task_ids()`.
 >   * Functions for validating config files: `validate_config()`,`validate_model_metadata_schema()`, `validate_hub_config()`, `view_config_val_errors()`.